### PR TITLE
Use version tag for `Elasticsearch` in `docker-compose.yml` file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ redis:
     - "6379:6379"
 
 elasticsearch:
-  image: elasticsearch
+  image: elasticsearch:6.5.2
   ports:
     - "9200:9200"
     - "9300:9300"


### PR DESCRIPTION
From [dockerhub](https://hub.docker.com/_/elasticsearch/) repo for `elastisearch` library:
`Note: Pulling an image requires using a specific version number tag. The latest tag is not supported.`